### PR TITLE
一時的にNodeバージョンを18.13に固定する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.4
-FROM node:18
+# NOTE: Temporary locking the Node version to 18.13. ref: https://github.com/aoirint/aoirint.com/issues/68
+FROM node:18.13
 
 RUN <<EOF
   apt-get update


### PR DESCRIPTION
デプロイが失敗しているので、Nodeバージョンを固定して、いったんデプロイが成功するようにする。

- ref: #49